### PR TITLE
Prepare move to `cnabio` organization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 engineerd
+Copyright (c) 2019 The CNAB Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# PySigny
+
+PySigny is a very early experiment for implementing the CNAB Security specification in Python.
+
 ### Setup
 
 ```


### PR DESCRIPTION
This PR:

- [x] updates the MIT license to "The CNAB Authors"
- [x] updates readme to reflect this is an experimental project